### PR TITLE
Removed the covis-test-data git submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Deploy/covis-test-data"]
-	path = covis-test-data
-	url = https://github.com/COVIS-Sonar/covis-test-data.git


### PR DESCRIPTION
Removed the submodule link to the covis-test-data submodule.   Not using it anymore --- instead test data will be pulled from online as needed.